### PR TITLE
Update README: explain `package` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The basic Dashing format looks like this:
 ```json
 {
     "name": "Dashing",
+    "package": "dashing",
     "index":"index.html",
     "icon32x32": "icon.png",
     "externalURL": "https://github.com/technosophos/dashing",
@@ -67,7 +68,8 @@ The basic Dashing format looks like this:
 }
 ```
 
-- name: Name of the package
+- name: Human-oriented name of the package
+- package: Computer-oriented name of the package (one word recommended)
 - index: Default index file in the existing docs
 - icon32x32: a 32x32 pixel PNG icon
 - externalURL: the base URL of the docs


### PR DESCRIPTION
It's present in the generated `dashing.json` file but wasn't documented here.